### PR TITLE
build: Never set persist.sys.usb.config=none in recovery

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1283,6 +1283,8 @@ define build-recoveryramdisk
             >> $(TARGET_RECOVERY_ROOT_OUT)/prop.default)
   $(hide) cat $(recovery_build_props) \
           >> $(TARGET_RECOVERY_ROOT_OUT)/prop.default
+  # Never allow persist.sys.usb.config to be set to none in recovery
+  $(hide) sed -i 's/persist.sys.usb.config=none/persist.sys.usb.config=adb/g' $(TARGET_RECOVERY_ROOT_OUT)/prop.default
   $(hide) ln -sf prop.default $(TARGET_RECOVERY_ROOT_OUT)/default.prop
   $(BOARD_RECOVERY_IMAGE_PREPARE)
   $(if $(filter true,$(BOARD_BUILD_SYSTEM_ROOT_IMAGE)), \


### PR DESCRIPTION
This is the dirtiest of hacks, but I don't see any other way to
have ro.adb.secure=1 in /system AND have ADB enabled in recovery
on recovery-in-boot devices.

Change-Id: I171185db8418b824c2ed586c7d521d99e838e96c