### PR TITLE
Bump Security String to 2019-01-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2018-12-05
+      PLATFORM_SECURITY_PATCH := 2019-01-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:           References:  Type:  Severity:  Updated AOSP versions:
CVE-2018-9582  A-112031362  EoP    High       8.0, 8.1, 9
CVE-2018-9583  A-112860487  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9584  A-114047681  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9585  A-117554809  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9586  A-116754444  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9587  A-113597344  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9588  A-111450156  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9589  A-111893132  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9590  A-115900043  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9591  A-116108738  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9592  A-116319076  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9593  A-116722267  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9594  A-116791157  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9

Not Implemented:
================
None

Not Applicable:
===============
None

Change-Id: I95c9d9ce26381b18f1fd392c2dd9903da84d998a