### PR TITLE
Bump Security String to 2019-02-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-01-05
+      PLATFORM_SECURITY_PATCH := 2019-02-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:           References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-1987  A-118143775  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-1988  A-118372692  RCE    Critical   8.0, 8.1, 9
CVE-2019-1991  A-110166268  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-1992  A-116222069  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-1993  A-119819889  EoP    High       8.0, 8.1, 9
CVE-2019-1994  A-117770924  EoP    High       8.0, 8.1, 9
CVE-2019-1995  A-32589229   ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-1996  A-111451066  ID     High       8.0, 8.1, 9
CVE-2019-1997  A-117508900  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:           References:  Type:  Severity:  Updated AOSP versions:
CVE-2017-17760 A-78029030   RCE    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9 (opencv 3.3.1)
CVE-2017-18009 A-78026242   ID     Moderate   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9 (opencv 3.3.1)
CVE-2018-5268  A-78029634   RCE    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9 (opencv 3.3.1)
CVE-2018-5269  A-78029727   RCE    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9 (opencv 3.3.1)
CVE-2019-1986  A-117838472  RCE    Critical   9
CVE-2019-1998  A-116055338  DoS    High       9

Change-Id: Ic453aa1381d3b49d61df287632c24a51ef0c8241