### PR TITLE
Bump Security String to 2019-03-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-02-05
+      PLATFORM_SECURITY_PATCH := 2019-03-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2018-9561   A-111660010  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9563   A-114237888  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-9564   A-114238578  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2018-20346  A-121156452  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-1989   A-118399205  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-1990   A-118453553  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2003   A-116321860  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2004   A-115739809  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2005   A-68777217   EoP    Moderate   8.0, 8.1, 9
CVE-2019-2007   A-120789744  EoP    High       8.1, 9
CVE-2019-2008   A-122309228  EoP    High       8.0, 8.1, 9
CVE-2019-2009   A-120665616  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2010   A-118152591  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2011   A-120084106  EoP    High       8.0, 8.1, 9
CVE-2019-2012   A-120497437  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2013   A-120497583  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2014   A-120499324  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2015   A-120503926  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2016   A-120664978  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2017   A-121035711  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2018   A-110172241  EoP    High       8.1, 9
CVE-2019-2019   A-115635871  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2020   A-116788646  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2021   A-120428041  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2022   A-120506143  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2023   A-121035042  EoP    High       8.0, 8.1, 9

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-1985   A-118694079  EoP    High       7.0, 7.1.1, 7.1.2, 8.0
CVE-2019-2006   A-116665972  EoP    High       9

Change-Id: I6abcae2ef3b37197a865d26a3a0c9e87817128fc