### PR TITLE
Bump Security String to 2019-04-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-03-05
+      PLATFORM_SECURITY_PATCH := 2019-04-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2027   A-119120561  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2028   A-120644655  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2029   A-120612744  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2031   A-120502559  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2032   A-121145627  EoP    High       8.0, 8.1, 9
CVE-2019-2034   A-122035770  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2035   A-122320256  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2037   A-119870451  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2038   A-121259048  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2039   A-121260197  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2026   A-120866126  EoP    High       8.0
CVE-2019-2030   A-119496789  EoP    High       9
CVE-2019-2033   A-121327565  EoP    High       9
CVE-2019-2040   A-122316913  ID     High       9
CVE-2019-2041   A-122034690  EoP    High       8.1, 9 (device-specific)

Change-Id: If8058eb1724d218f6445d667686e00388469a937