### PR TITLE
Bump Security String to 2019-09-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-08-05
+      PLATFORM_SECURITY_PATCH := 2019-09-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2115   A-129768470  EoP    High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2123   A-34175893   EoP    High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2124   A-127320867  ID     High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2174   A-132927376  EoP    High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2176   A-134420911  RCE    Critical   8.0, 8.1, 9
CVE-2019-2177   A-132456322  RCE    High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2178   A-124462242  EoP    High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2179   A-126200054  ID     High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2180   A-110899492  ID     High       8.0, 8.1, 9

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2103   A-120610669  ID     High       9
CVE-2019-2108   A-130025324  RCE    Critical   10
CVE-2019-2175   A-135551349  EoP    High       9
CVE-2019-9254   A-130164289  EoP    High       10

Change-Id: If51be0ccb0d4d692410fb0d581a5f571f0a8c53f