### PR TITLE
Bump Security String to 2019-10-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -231,7 +231,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-09-05
+      PLATFORM_SECURITY_PATCH := 2019-10-05
 endif
 
 ifndef PLATFORM_SECURITY_PATCH_TIMESTAMP


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2114   A-123700348  EoP    High       8.0, 8.1, 9
CVE-2019-2173   A-123013720  EoP    High       7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2184   A-134578122  RCE    Critical   7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2185   A-136173699  RCE    Critical   7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2186   A-136175447  RCE    Critical   7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2187   A-124940143  ID     High       7.1.1, 7.1.2, 8.0, 8.1, 9, 10

Previously Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2110   A-69703445   ID     High       9

Not Implemented:
================
None

Not Applicable (platform source):
===============
None

Change-Id: Iede305c69c7da37ed77861ed46e5cf85ef1f852d