### PR TITLE
Default TARGET_COPY_OUT_ODM to $(TARGET_COPY_OUT_VENDOR)/odm

### DIFF
--- a/core/envsetup.mk
+++ b/core/envsetup.mk
@@ -211,6 +211,17 @@ TARGET_COPY_OUT_VENDOR := $(_vendor_path_placeholder)
 ###########################################
 
 ###########################################
+# Define TARGET_COPY_OUT_ODM to a placeholder, for at this point
+# we don't know if the device wants to build a separate odm.img
+# or just build odm stuff into vendor.img.
+# A device can set up TARGET_COPY_OUT_ODM to "odm" in its
+# BoardConfig.mk.
+# We'll substitute with the real value after loading BoardConfig.mk.
+_odm_path_placeholder := ||ODM-PATH-PH||
+TARGET_COPY_OUT_ODM := $(_odm_path_placeholder)
+###########################################
+
+###########################################
 # Define TARGET_COPY_OUT_PRODUCT to a placeholder, for at this point
 # we don't know if the device wants to build a separate product.img
 # or just build product stuff into system.img.
@@ -296,6 +307,15 @@ BOARD_USES_VENDORIMAGE := true
 else ifdef BOARD_USES_VENDORIMAGE
 $(error TARGET_COPY_OUT_VENDOR must be set to 'vendor' to use a vendor image)
 endif
+
+###########################################
+# Now we can substitute with the real value of TARGET_COPY_OUT_ODM
+ifeq ($(TARGET_COPY_OUT_ODM),$(_odm_path_placeholder))
+TARGET_COPY_OUT_ODM := $(TARGET_COPY_OUT_VENDOR)/odm
+else ifeq ($(filter odm $(TARGET_COPY_OUT_VENDOR)/odm,$(TARGET_COPY_OUT_ODM)),)
+$(error TARGET_COPY_OUT_ODM must be either 'odm' or '$(TARGET_COPY_OUT_VENDOR)/odm', seeing '$(TARGET_COPY_OUT_ODM)'.)
+endif
+PRODUCT_COPY_FILES := $(subst $(_odm_path_placeholder),$(TARGET_COPY_OUT_ODM),$(PRODUCT_COPY_FILES))
 
 ###########################################
 # Now we can substitute with the real value of TARGET_COPY_OUT_PRODUCT


### PR DESCRIPTION
This is to match the /odm/* symlinks currently created and also
matches the default in master. This does not add any other odm
handling, such as building an odm image.

Change-Id: Iea950420a84cf0bc4da6ede7605f8e1acc64144e