### PR TITLE
Bump Security String to 2019-11-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-10-05
+      PLATFORM_SECURITY_PATCH := 2019-11-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:            References:       Type:  Severity:  Updated AOSP versions:
CVE-2019-2193	A-132261064[2]    EoP    High       8.0, 8.1, 9, 10
CVE-2019-2195	A-139186193	  EoP    High       8.0, 8.1, 9, 10
CVE-2019-2211	A-135269669[2]	  ID     High       8.0, 8.1, 9, 10
CVE-2019-2197	A-138529441	  ID     High       8.0, 8.1, 9, 10
CVE-2019-2201	A-120551338	  RCE    High       8.0, 8.1, 9, 10
CVE-2019-2203	A-137370777	  EoP    High       8.0, 8.1, 9, 10
CVE-2019-2204	A-138442295       RCE    Critical   9
CVE-2019-2205	A-139806216	  RCE    Critical   8.0, 8.1, 9, 10
CVE-2019-2206	A-139188579	  RCE    Critical   8.0, 8.1, 9, 10
CVE-2019-2207	A-124524315	  EoP    High	    8.0, 8.1, 9, 10
CVE-2019-2212	A-139690488[2][3] ID     High	    8.0, 8.1, 9, 10
CVE-2019-2208   A-138441919       ID     High       9
CVE-2019-2209	A-139287605	  ID     High	    8.0, 8.1, 9, 10
CVE-2019-2196	A-135269143[...]  ID     High       8.0, 8.1, 9, 10
CVE-2019-2198	A-135270103[...]  ID     High       8.0, 8.1, 9, 10
CVE-2019-2036	A-79703832	  EoP    High       8.0, 8.1, 9, 10

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:     Type:   Severity:  Updated AOSP versions:
CVE-2019-2192	A-138441555	EoP	High       9, 10
CVE-2019-2199	A-138650665	EoP	High	   10
CVE-2019-2202	A-137283376	EoP	High	   9, 10
CVE-2019-2233	A-140486529	EoP	High       10
CVE-2019-2210	A-139148442*	EoP	High       9, 10

Change-Id: I2d0fa3d665458eb3ec3643a5863de50e53ddefd8