### PR TITLE
Bump Security String to 2019-12-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -231,7 +231,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-11-05
+      PLATFORM_SECURITY_PATCH := 2019-12-05
 endif
 
 ifndef PLATFORM_SECURITY_PATCH_TIMESTAMP


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2219   A-119041698  ID     High       9, 10
CVE-2019-2220   A-138636979  ID     High       9, 10
CVE-2019-2222   A-140322595  RCE    Moderate   10
                             RCE    Critical   8.0, 8.1, 9
CVE-2019-2223   A-140692129  RCE    Moderate   10
                             RCE    Critical   8.0, 8.1, 9
CVE-2019-2224   A-140328986  RCE    High       8.0, 8.1, 9, 10
CVE-2019-2225   A-110433804  EoP    High       8.0, 8.1, 9, 10
CVE-2019-2226   A-140152619  ID     High       8.0, 8.1, 9, 10
CVE-2019-2227   A-140768453  ID     High       9, 10
CVE-2019-2228   A-111210196  ID     High       8.0, 8.1, 9, 10
CVE-2019-2229   A-139803872  ID     High       8.0, 8.1, 9, 10
CVE-2019-2231   A-141955555  ID     High       9, 10
CVE-2019-2232   A-140632678  DoS    Critical   8.0, 8.1, 9, 10

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2217   A-141003796  EoP    High       10
CVE-2019-2218   A-141169173  EoP    High       10
CVE-2019-2221   A-138583650  EoP    Moderate   10
CVE-2019-2230   A-141170038  ID     High       10
CVE-2019-9464   A-141028068  EoP    High       10

Change-Id: Iaaeb2448997ba120d4d9e91225412195e7999ce6