### PR TITLE
Bump Security String to 2020-08-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -231,7 +231,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2020-07-05
+      PLATFORM_SECURITY_PATCH := 2020-08-05
 endif
 
 ifndef PLATFORM_SECURITY_PATCH_TIMESTAMP


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0108   A-140108616  EoP    High       8.1, 9, 10
CVE-2020-0238   A-150946634  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0239   A-151095863  ID     High       9, 10
CVE-2020-0241   A-151456667  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0242   A-151643722  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0243   A-151644303  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0249   A-154719656  ID     High       8.0, 8.1, 9, 10
CVE-2020-0256   A-152874864  EoP    High       8.0, 8.1, 9, 10

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0240   A-150706594  RCE    High       10
CVE-2020-0247   A-156087409  DoS    High       8.0, 8.1, 10
CVE-2020-0248   A-154627439  ID     High       10
CVE-2020-0250   A-154934934  ID     High       10
CVE-2020-0257   A-156741968  EoP    High       10
CVE-2020-0258   A-157598956  ID     High       10

Change-Id: Iad591e9d9b95475d47ed6b8742285af42a37d686